### PR TITLE
ensure since() is updated after compaction

### DIFF
--- a/test/compaction.js
+++ b/test/compaction.js
@@ -204,9 +204,13 @@ tape('shift many blocks', async (t) => {
     progressArr.push(stats)
   })
 
+  t.equals(log.since.value, 44 + 6, 'since before compaction')
+
   const [err] = await run(log.compact)()
   await run(log.onDrain)()
   t.error(err, 'no error when compacting')
+
+  t.equals(log.since.value, 33 + 6, 'since after compaction')
 
   t.deepEquals(
     progressArr,


### PR DESCRIPTION
## Context

Working on putting compaction, deletes, truncation in Manyverse and noticed that log.since.value isn't updated to reflect the new positions in the log available for writes.

## Problem

When truncate (post-compaction) actually deletes some blocks, we correctly update the log.since() (via `loadLatestBlock()`). **But** when there was no need for truncation, we didn't run `loadLatestBlock()` and the `log.since()` was not updated.

## Solution

When truncating, and we notice the number of blocks will be the same, still "load" the latest block so to scan that block and find the offset of the last good record. And set `since` to that.

The 1st commit adds a test that *already* passes.
The 2nd commit adds a test that *fails*. :x: 
The 3rd commit fixes that test. :heavy_check_mark: 