### PR TITLE
Switch from hashlru to quick-lru

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-only
 
-const Cache = require('hashlru')
+const Cache = require('@alloc/quick-lru')
 const RAF = require('polyraf')
 const Obv = require('obz')
 const debounce = require('lodash.debounce')
@@ -43,7 +43,7 @@ const DEFAULT_WRITE_TIMEOUT = 250
 const DEFAULT_VALIDATE = () => true
 
 module.exports = function AsyncAppendOnlyLog(filename, opts) {
-  const cache = new Cache(1024) // This is potentially 64 MiB!
+  const cache = new Cache({ maxSize: 1024 }) // This is potentially 64 MiB!
   const raf = RAF(filename)
   const blockSize = (opts && opts.blockSize) || DEFAULT_BLOCK_SIZE
   const codec = (opts && opts.codec) || DEFAULT_CODEC

--- a/index.js
+++ b/index.js
@@ -475,7 +475,7 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
     const size = (latestBlockIndex + 1) * blockSize
     const newSize = (newLatestBlockIndex + 1) * blockSize
     for (let i = newLatestBlockIndex + 1; i < latestBlockIndex; ++i) {
-      cache.remove(i)
+      cache.delete(i)
     }
     truncateWithFSync(newSize, function onTruncateWithFSyncDone(err) {
       if (err) return cb(err)

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "LICENSES/*"
   ],
   "dependencies": {
+    "@alloc/quick-lru": "^5.2.0",
     "debug": "^4.2.0",
-    "hashlru": "^2.3.0",
     "is-buffer-zero": "^1.0.0",
     "lodash.debounce": "^4.0.8",
     "looper": "^4.0.0",


### PR DESCRIPTION
Background:

This [PR](https://github.com/dominictarr/hashlru/pull/21) lead me to [quick-lru](https://www.npmjs.com/package/quick-lru) which sadly is ESM. But they still maintain an older version: https://github.com/sindresorhus/quick-lru/releases/tag/v6.0.0.

This PR:

Replace hashlru with quick-lru that uses a map internally. I tried benchmarking this but couldn't see a big difference. One area where this might help is in compaction.