### PR TITLE
add test for live pull-stream

### DIFF
--- a/test/stream-abort.js
+++ b/test/stream-abort.js
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2022 Andre 'Staltz' Medeiros <contact@staltz.com>
+//
+// SPDX-License-Identifier: CC0-1.0
+
+const tape = require('tape')
+const fs = require('fs')
+const toPull = require('push-stream-to-pull-stream/source')
+const pull = require('pull-stream')
+const Log = require('../')
+
+const filename = '/tmp/aaol-abort-live-pull-stream.log'
+
+try {
+  fs.unlinkSync(filename)
+} catch (_) {}
+const log = Log(filename, { blockSize: 64 * 1024 })
+
+const msg1 = Buffer.alloc(10).fill(0x10)
+const msg2 = Buffer.alloc(20).fill(0x20)
+const msg3 = Buffer.alloc(30).fill(0x30)
+
+tape('abort live push-stream-to-pull-stream should not end with err', (t) => {
+  t.plan(8)
+  log.append(msg1, (err) => {
+    t.error(err, 'no err to append msg1')
+    log.append(msg2, (err) => {
+      t.error(err, 'no err to append msg2')
+      const expected = [msg1, msg2, msg3]
+      const logPushStream = log.stream({ live: true, offsets: false })
+      const logPullStream = toPull(logPushStream)
+      pull(
+        logPullStream,
+        pull.drain(
+          (buf) => {
+            t.deepEqual(buf, expected.shift())
+            if (expected.length === 0) {
+              log.close(() => {
+                t.pass('closed AAOL')
+              })
+            }
+          },
+          (err) => {
+            t.error(err, 'no err when pull.draining')
+          }
+        )
+      )
+    })
+  })
+  log.append(msg3, (err) => {
+    t.error(err, 'no err to append msg3')
+  })
+})


### PR DESCRIPTION
## Context

Sometimes in Manyverse I would get the error below, but today I also got this error in some test code in ssb-db2, and that finally allowed me to debug it easily.

```
Uncaught Exception at  uncaughtException : Error: async-append-only-log stream is closed
    at streamClosedErr (./node_modules/async-append-only-log/errors.js:46:10)
    at closeAfterDeletesFlushed (./node_modules/async-append-only-log/index.js:517:57)
    at onDeletesFlushed (./node_modules/async-append-only-log/index.js:308:42)
    at closeAfterHavingDrained (./node_modules/async-append-only-log/index.js:516:7)
    at onDrain (./node_modules/async-append-only-log/index.js:536:67)
    at close (./node_modules/async-append-only-log/index.js:515:5)
    at Object.waitForLogLoaded [as close] (./node_modules/async-append-only-log/index.js:527:12)
    at ./db.js:663:11
    at ./node_modules/multicb/index.js:41:13
    at ./node_modules/levelup/lib/levelup.js:142:16
```

## Problem

As you can see, it's the `streamClosedErr` from AAOL, but what's puzzling is that this error is only used when closing the AAOL, it's sent to `stream.abort()`. But the push-stream implementation we have doesn't *throw* that error anywhere.

Finally, I realized that this throwing happens somewhere in the pull-stream stack. We have live log streams that are converted to pull-stream.

## Solution

1st :x: 2nd :heavy_check_mark: 

Just abort with `true`. I don't see a real need to have the abortion as an actual Error, since in this case we just want to cancel the live streams and close() AAOL.