### PR TITLE
throttle compactionProgress with 1sec

### DIFF
--- a/test/compaction.js
+++ b/test/compaction.js
@@ -290,20 +290,6 @@ tape('shift many blocks', async (t) => {
         done: false,
       },
       {
-        startOffset: 11,
-        compactedOffset: 22,
-        unshiftedOffset: 28,
-        percent: 0.4358974358974359,
-        done: false,
-      },
-      {
-        startOffset: 11,
-        compactedOffset: 33,
-        unshiftedOffset: 44,
-        percent: 0.8461538461538461,
-        done: false,
-      },
-      {
         sizeDiff: 11, // the log is now 1 block shorter
         percent: 1,
         done: true,
@@ -601,13 +587,6 @@ tape('startOffset is correct', async (t) => {
         compactedOffset: 0,
         unshiftedOffset: 3,
         percent: 0.25,
-        done: false,
-      },
-      {
-        startOffset: 0,
-        compactedOffset: 9,
-        unshiftedOffset: 12,
-        percent: 1,
         done: false,
       },
       {

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -90,12 +90,11 @@ tape('compact waits for old log.streams to end', async (t) => {
   await run(log.onDrain)()
   t.pass(`appended ${RECORDS} records`)
 
-  await run(log.del)(0)
-  await run(log.del)(3)
-  await run(log.del)(6)
-  await run(log.del)(9)
+  await run(log.del)(RECORDS * 0.9 * 4)
+  await run(log.del)(RECORDS * 0.9 * 4 + 4)
+  await run(log.del)(RECORDS * 0.9 * 4 + 8)
   await run(log.onDeletesFlushed)()
-  t.pass(`deleted 4 records`)
+  t.pass(`deleted 3 records`)
 
   let compactionStarted
   log.compactionProgress((stats) => {


### PR DESCRIPTION
## Problem

Using `compactionProgress` in the UI is not good, because for each record shifted/compacted, it updates, which means it's spamming the frontend a lot. We should do something smarter, like ssb-db2 `status` does.

## Solution

Throttle the progress updates such that they are not "closer" than 1 second to each other. The exceptions are: the first `done = false` update is always emitted (this is important so the UI knows that compaction has started), and any `done = true` update is always emitted.

1st :x: 2nd :heavy_check_mark: 