### PR TITLE
new API log.stats()

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,18 @@ log.since((offset) => {
 })
 ```
 
+### Get statistics on deleted records
+
+Among other things, this is useful for knowing how much storage space you could
+save by running compaction, to eliminate deleted records.
+
+```js
+log.stats((err, stats) => {
+  console.log(stats)
+  // { totalBytes, totalCount, deletedBytes, deletedCount }
+})
+```
+
 ### Compact the log (remove deleted records)
 
 ```js

--- a/index.js
+++ b/index.js
@@ -456,7 +456,7 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
   }
 
   function onStreamsDone(cb) {
-    if (self.streams.every((stream) => stream.cursor === since.value)) {
+    if ([...self.streams].every((stream) => stream.cursor === since.value)) {
       return cb()
     }
     const interval = setInterval(function checkIfStreamsDone() {
@@ -537,7 +537,7 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
     onDrain(function closeAfterHavingDrained() {
       onDeletesFlushed(function closeAfterDeletesFlushed() {
         for (const stream of self.streams) stream.abort(true)
-        self.streams = []
+        self.streams.clear()
         raf.close(cb)
       })
     })
@@ -587,7 +587,7 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
     compactionProgress,
     stream(opts) {
       const stream = new Stream(self, opts)
-      self.streams.push(stream)
+      self.streams.add(stream)
       return stream
     },
 
@@ -602,6 +602,6 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
     getNextBlockStart,
     getDataNextOffset,
     getBlock,
-    streams: [],
+    streams: new Set(),
   })
 }

--- a/stream.js
+++ b/stream.js
@@ -172,8 +172,7 @@ Stream.prototype.liveResume = function liveResume() {
 
 Stream.prototype.abort = function abort(err) {
   this.state = STREAM_STATE.ENDED
-  const i = this.log.streams.indexOf(this)
-  if (~i) this.log.streams.splice(i, 1)
+  this.log.streams.delete(this)
   if (!this.sink.ended && this.sink.end) {
     this.sink.ended = true
     this.sink.end(err === true ? null : err)

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -32,6 +32,12 @@ tape('compact a log that does not have holes', async (t) => {
   await run(log.onDrain)()
   t.pass('append two records')
 
+  const [, stats] = await run(log.stats)()
+  t.equals(stats.totalCount, 2, 'stats.totalCount')
+  t.ok(stats.totalBytes, 'stats.totalBytes')
+  t.equals(stats.deletedCount, 0, 'stats.deletedCount')
+  t.equals(stats.deletedBytes, 0, 'stats.deletedBytes')
+
   const progressArr = []
   log.compactionProgress((stats) => {
     progressArr.push(stats)
@@ -74,7 +80,7 @@ tape('compact a log that does not have holes', async (t) => {
 
 tape('compact waits for old log.streams to end', async (t) => {
   t.timeoutAfter(20000)
-  const BLOCKSIZE = 100;
+  const BLOCKSIZE = 100
   const file = '/tmp/compaction-test_' + Date.now() + '.log'
   const log = Log(file, {
     blockSize: BLOCKSIZE,
@@ -95,6 +101,12 @@ tape('compact waits for old log.streams to end', async (t) => {
   await run(log.del)(RECORDS * 0.9 * 4 + 8)
   await run(log.onDeletesFlushed)()
   t.pass(`deleted 3 records`)
+
+  const [, stats] = await run(log.stats)()
+  t.equals(stats.totalCount, RECORDS, 'stats.totalCount')
+  t.ok(stats.totalBytes, 'stats.totalBytes')
+  t.equals(stats.deletedCount, 3, 'stats.deletedCount')
+  t.equals(stats.deletedBytes, 12, 'stats.deletedBytes')
 
   let compactionStarted
   log.compactionProgress((stats) => {

--- a/test/idempotent-resume.js
+++ b/test/idempotent-resume.js
@@ -61,7 +61,7 @@ tape('a second resume() on the same stream is idempotent', function (t) {
 })
 
 tape('close', function (t) {
-  t.equal(log.streams.length, 0, 'no open streams')
+  t.equal(log.streams.size, 0, 'no open streams')
   log.close(() => {
     t.end()
   })

--- a/test/stream-pausable.js
+++ b/test/stream-pausable.js
@@ -66,7 +66,7 @@ tape('pausable', function (t) {
 })
 
 tape('close', function (t) {
-  t.equal(log.streams.length, 0, 'no open streams')
+  t.equal(log.streams.size, 0, 'no open streams')
   log.stream({ offsets: false }).pipe({
     paused: false,
     write: function () {},

--- a/test/stream.js
+++ b/test/stream.js
@@ -300,7 +300,7 @@ tape('double live', function (t) {
 })
 
 tape('close', function (t) {
-  t.equal(log.streams.length, 0, 'no open streams')
+  t.equal(log.streams.size, 0, 'no open streams')
   log.stream({ offsets: false }).pipe({
     paused: false,
     write: function () {},


### PR DESCRIPTION
## Context

Manyverse will need to know how much space _would_ be saved by compaction *before* kickstarting compaction. We don't want the user to reindex leveldb in vain if there are just a handful of deleted records.

## Problem

There is no way of knowing, with the current API, such information, without actually running compaction.

## Solution

`log.stats()` is a new API that does a scan on the log (and this is implemented in AAOL and not in ssb-db2 so to avoid the extra log scan logic it has such as `decrypt`), counting how many deleted records there are and how much space in total those deleted records occupy. This would then be bubbled up to the UI, to the user, so the user can make an informed decision when to compact.

`log.stream(opts)` now also supports `opts.sizes`, to achieve the above.

I also changed `log.streams` from Array to Set, because we don't need the ordering that arrays give us, and `Set.delete` is simpler than splice.