### PR TITLE
include holesFound in compactionProgress stats

### DIFF
--- a/test/compaction.js
+++ b/test/compaction.js
@@ -57,6 +57,7 @@ tape('compact a log that does not have holes', async (t) => {
       },
       {
         sizeDiff: 0,
+        holesFound: 0,
         percent: 1,
         done: true,
       },
@@ -302,6 +303,7 @@ tape('shift many blocks', async (t) => {
       },
       {
         sizeDiff: 11, // the log is now 1 block shorter
+        holesFound: 3,
         percent: 1,
         done: true,
       },
@@ -602,6 +604,7 @@ tape('startOffset is correct', async (t) => {
       },
       {
         sizeDiff: 1,
+        holesFound: 1,
         percent: 1,
         done: true,
       },
@@ -699,6 +702,7 @@ tape('recovers from crash just after persisting state', async (t) => {
       },
       {
         sizeDiff: 1,
+        holesFound: 0,
         percent: 1,
         done: true,
       },


### PR DESCRIPTION
Context: https://github.com/ssbc/jitdb/pull/221

Important note: `holesFound` does not count holes from the *previous* compaction run (assume there was a crash + resume), i.e. the counter is not kept in the state file. The good news is that we don't need the counter in the state file because there are no jitdb queries that keep state before and after an app crash ( https://github.com/ssbc/jitdb/pull/221 ).