### PR TITLE
update compactionProgress as soon as compaction starts

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,8 +67,8 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
   let compaction = null
   const compactionProgress = Obv().set(
     Compaction.stateFileExists(filename)
-      ? { done: false }
-      : { sizeDiff: 0, percent: 1, done: true }
+      ? { percent: 0, done: false }
+      : { percent: 1, done: true, sizeDiff: 0 }
   )
   const waitingCompaction = []
 
@@ -538,6 +538,9 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
     onStreamsDone(function startCompactAfterStreamsDone() {
       onDrain(function startCompactAfterDrain() {
         onDeletesFlushed(function startCompactAfterDeletes() {
+          if (compactionProgress.value.done) {
+            compactionProgress.set({ percent: 0, done: false })
+          }
           compaction = new Compaction(self, (err, stats) => {
             compaction = null
             if (err) return cb(err)

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -50,17 +50,9 @@ tape('compact a log that does not have holes', async (t) => {
   t.deepEquals(
     progressArr,
     [
-      {
-        sizeDiff: 0,
-        percent: 1,
-        done: true,
-      },
-      {
-        sizeDiff: 0,
-        holesFound: 0,
-        percent: 1,
-        done: true,
-      },
+      { percent: 1, done: true, sizeDiff: 0 },
+      { percent: 0, done: false },
+      { percent: 1, done: true, sizeDiff: 0, holesFound: 0 },
     ],
     'progress events'
   )
@@ -293,6 +285,10 @@ tape('shift many blocks', async (t) => {
         sizeDiff: 0,
         percent: 1,
         done: true,
+      },
+      {
+        percent: 0,
+        done: false,
       },
       {
         startOffset: 11,
@@ -596,6 +592,10 @@ tape('startOffset is correct', async (t) => {
         done: true,
       },
       {
+        percent: 0,
+        done: false,
+      },
+      {
         startOffset: 0,
         compactedOffset: 0,
         unshiftedOffset: 3,
@@ -691,6 +691,7 @@ tape('recovers from crash just after persisting state', async (t) => {
     progressArr,
     [
       {
+        percent: 0,
         done: false,
       },
       {


### PR DESCRIPTION
**Context:** I intend to move [`reindexJitdbPath` from ssb-db2](https://github.com/ssbc/ssb-db2/blob/2f2b23bccc16c35d3ea4cb7b9334b84495bb3a80/db.js#L818) to jitdb, for reasons I can explain soon, but for that I need to create the file immediately as soon as compaction starts (because a crash could occur during compaction).

This PR sets `compactionProgress` to done=false right before the compaction algorithm starts, giving listeners the opportunity to do something before compaction.