### PR TITLE
log.stream to support push.drain()

### DIFF
--- a/compaction.js
+++ b/compaction.js
@@ -237,14 +237,12 @@ function Compaction(log, onDone) {
   }
 
   function findFirstDeletedOffset(cb) {
-    let once = false
     log.stream({ offsets: true, values: true }).pipe(
       push.drain(
         function sinkToFindFirstDeleted(record) {
-          if (record.value === null && !once) {
-            once = true
+          if (record.value === null) {
             cb(null, record.offset)
-            return false
+            return false // abort push.drain
           }
         },
         function sinkEndedLookingForDeleted() {
@@ -255,14 +253,12 @@ function Compaction(log, onDone) {
   }
 
   function findNonDeletedOffsetGTE(gte, cb) {
-    let once = false
     log.stream({ gte, offsets: true, values: true }).pipe(
       push.drain(
         function sinkToFindNonDeleted(record) {
-          if (record.value !== null && !once) {
-            once = true
+          if (record.value !== null) {
             cb(null, record.offset)
-            return false
+            return false // abort push.drain
           }
         },
         function sinkEndedLookingForNonDeleted() {

--- a/stream.js
+++ b/stream.js
@@ -94,8 +94,7 @@ Stream.prototype._writeToSink = function _writeToSink(value, size) {
 // returns a new BLOCK_STATE
 Stream.prototype._handleBlock = function _handleBlock(blockBuf) {
   while (true) {
-    if (this.sink.paused) return BLOCK_STATE.PAUSED
-    if (this.sink.ended) return BLOCK_STATE.PAUSED
+    if (this.sink.paused || this.sink.ended) return BLOCK_STATE.PAUSED
 
     const [offset, value, size] = this.log.getDataNextOffset(
       blockBuf,

--- a/stream.js
+++ b/stream.js
@@ -95,6 +95,7 @@ Stream.prototype._writeToSink = function _writeToSink(value, size) {
 Stream.prototype._handleBlock = function _handleBlock(blockBuf) {
   while (true) {
     if (this.sink.paused) return BLOCK_STATE.PAUSED
+    if (this.sink.ended) return BLOCK_STATE.PAUSED
 
     const [offset, value, size] = this.log.getDataNextOffset(
       blockBuf,

--- a/test/stream.js
+++ b/test/stream.js
@@ -130,6 +130,26 @@ tape('offsets', function (t) {
   )
 })
 
+tape('push.drain', function (t) {
+  const expected = [0, 12]
+
+  log.stream({ offsets: true, values: false }).pipe(
+    push.drain((x) => {
+      t.true(expected.length > 0)
+      t.equals(x, expected.shift())
+      if (x === 12) return false
+      if (x === 34) t.fail('should not receive more values after abort')
+    }, (err) => {
+      t.fail('end should not be called')
+    })
+  )
+
+  setTimeout(() => {
+    t.equals(expected.length, 0)
+    t.end()
+  }, 1000)
+})
+
 tape('pausable', function (t) {
   let i = 0
   let sink


### PR DESCRIPTION
## Context

[jitdb uses `push.drain()` to scan the log](https://github.com/ssbc/jitdb/blob/b17fa8bbd0520368a08ae0e3651b3ccd88674ae7/index.js#L1292-L1311), and to my surprise, after the `return false` to abort the sink, the sink still kept receiving new records!

## Problem

When using an AAOL push-stream with `push.drain()` from the `push-stream` toolkit, if you `return false` to abort the sink, then the push-stream source *keeps feeding you values*. See new test added.

## Solution

At first I thought that push-stream `push.drain()` is wrong, and maybe it still is, because push-stream is a somewhat incomplete project. For instance, what's the difference between `this.paused` and `this.ended`? Do only sources have `this.ended`? (This is complicated by the fact that some objects are BOTH push-stream source and push-stream sink)

Instead of fighting push-stream, fixing its semantics or whatever, I decided to just add one line of code in AAOL to fix the test that I added.

In the future I'd like to replace push-stream with something more proven and solid, as well as performant, but I don't have the time for that now.

1st :x: 2nd :heavy_check_mark: 