### PR TITLE
avoid scanning the log for log.stats()

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ save by running compaction, to eliminate deleted records.
 ```js
 log.stats((err, stats) => {
   console.log(stats)
-  // { totalBytes, totalCount, deletedBytes, deletedCount }
+  // { totalBytes, deletedBytes }
 })
 ```
 

--- a/index.js
+++ b/index.js
@@ -547,6 +547,9 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
           compaction = new Compaction(self, (err, stats) => {
             compaction = null
             if (err) return cb(err)
+            deletedBytes = 0
+            const stats = JSON.stringify({ deletedBytes })
+            AtomicFile.writeFile(statsFilename, stats, 'utf8', () => {})
             compactionProgress.set({ ...stats, percent: 1, done: true })
             for (const callback of waitingCompaction) callback()
             waitingCompaction.length = 0

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "dependencies": {
     "@alloc/quick-lru": "^5.2.0",
+    "atomic-file-rw": "^0.3.0",
     "debug": "^4.2.0",
     "is-buffer-zero": "^1.0.0",
     "lodash.debounce": "^4.0.8",

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -139,7 +139,7 @@ tape('compact waits for old log.streams to end', async (t) => {
 
   const [, stats3] = await run(log2.stats)()
   t.equals(stats3.totalBytes, 208048, 'stats.totalBytes (3)')
-  t.equals(stats3.deletedBytes, 12, 'stats.deletedBytes (3)')
+  t.equals(stats3.deletedBytes, 0, 'stats.deletedBytes (3)')
 
   await run(log2.close)()
 


### PR DESCRIPTION
## Problem

Scanning the log is slow, some ~5 seconds on desktop and more on mobile.

I use `log.stats` to show charts on the new Manyverse Storage screen, and this means a 5 second delay to open that screen, waiting for the scan to end.

## Solution

The most important metric is `deletedBytes`, (because `totalBytes` is just `since.value` and the `totalCount` and `deletedCount` were never used yet by any other code), which can be persisted and incremented every time a delete occurs.

There's now an atomic file `log.bipf.stats` with stringified JSON to hold these stats, which at the moment is just `{ deletedBytes }`. This is much faster than scanning, but there is a slight chance that the calculation goes wrong if the stats file is deleted or corrupted.

## Breaking change?

Technically, removing `totalCount` and `deletedCount` is a breaking change, but for Reasons :tm: it would be best if we could publish the next version as a _patch_, not a major. (Reasons are: a new major would require updating ssb-db2 and this would force me to use ssb-db2 version 5 in Manyverse, which I don't want to use *yet* because when introducing compaction in production I don't want to introduce also feedFormats because I don't want crash reports about BOTH at the same time). If you think we really should publish a major, that's okay for me, I can point my package.json to use this specific branch of AAOL.