### PR TITLE
stats() smallest totalBytes should be zero

### DIFF
--- a/index.js
+++ b/index.js
@@ -528,11 +528,11 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
   function stats(cb) {
     if (since.value == null) {
       since((totalBytes) => {
-        cb(null, { totalBytes, deletedBytes })
+        cb(null, { totalBytes: Math.max(0, totalBytes), deletedBytes })
         return false
       })
     } else {
-      cb(null, { totalBytes: since.value, deletedBytes })
+      cb(null, { totalBytes: Math.max(0, since.value), deletedBytes })
     }
   }
 

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -24,6 +24,10 @@ tape('compact a log that does not have holes', async (t) => {
   const file = '/tmp/compaction-test_' + Date.now() + '.log'
   const log = Log(file, { blockSize: 10 })
 
+  const [, stats] = await run(log.stats)()
+  t.equals(stats.totalBytes, 0, 'stats.totalBytes (1)')
+  t.equals(stats.deletedBytes, 0, 'stats.deletedBytes (1)')
+
   const buf1 = Buffer.from('first')
   const buf2 = Buffer.from('second')
 
@@ -32,9 +36,9 @@ tape('compact a log that does not have holes', async (t) => {
   await run(log.onDrain)()
   t.pass('append two records')
 
-  const [, stats] = await run(log.stats)()
-  t.equals(stats.totalBytes, 10, 'stats.totalBytes')
-  t.equals(stats.deletedBytes, 0, 'stats.deletedBytes')
+  const [, stats2] = await run(log.stats)()
+  t.equals(stats2.totalBytes, 10, 'stats.totalBytes (2)')
+  t.equals(stats2.deletedBytes, 0, 'stats.deletedBytes (2)')
 
   const progressArr = []
   log.compactionProgress((stats) => {


### PR DESCRIPTION
**Problem:** `stats()` returns `totalBytes === -1` if the log has not yet been written to.

**Solution:** `since.value` at `-1` makes sense for internal programming, but here we want to measure only the number of bytes, so we cap the lowest value to be zero.

1st :x: 2nd :heavy_check_mark: 