### PR TITLE
fix live stream post-compaction

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -38,6 +38,13 @@ function delDuringCompactErr() {
   return new Error('Cannot delete while compaction is in progress')
 }
 
+function compactWithMaxLiveStreamErr() {
+  return new Error(
+    'Compaction cannot run if there are live streams ' +
+      'configured with opts.lt or opts.lte'
+  )
+}
+
 function appendLargerThanBlockErr() {
   return new Error('Data to be appended is larger than block size')
 }
@@ -61,6 +68,7 @@ module.exports = {
   outOfBoundsOffsetErr,
   deletedRecordErr,
   delDuringCompactErr,
+  compactWithMaxLiveStreamErr,
   appendLargerThanBlockErr,
   appendTransactionWantsArrayErr,
   unexpectedTruncationErr,

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const {
   appendLargerThanBlockErr,
   appendTransactionWantsArrayErr,
   unexpectedTruncationErr,
+  compactWithMaxLiveStreamErr,
 } = require('./errors')
 const Stream = require('./stream')
 const Record = require('./record')
@@ -548,6 +549,11 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
       debug('compaction already in progress')
       waitingCompaction.push(cb)
       return
+    }
+    for (const stream of self.streams) {
+      if (stream.live && (stream.max || stream.max_inclusive)) {
+        return cb(compactWithMaxLiveStreamErr())
+      }
     }
     onStreamsDone(function startCompactAfterStreamsDone() {
       onDrain(function startCompactAfterDrain() {

--- a/index.js
+++ b/index.js
@@ -563,6 +563,9 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
               if (err)
                 debug('error saving stats after compaction: %s', err.message)
             })
+            for (const stream of self.streams) {
+              if (stream.live) stream.postCompactionReset(since.value)
+            }
             compactionProgress.set({ ...stats, percent: 1, done: true })
             for (const callback of waitingCompaction) callback()
             waitingCompaction.length = 0

--- a/stream.js
+++ b/stream.js
@@ -184,10 +184,6 @@ Stream.prototype.liveResume = function liveResume() {
 }
 
 Stream.prototype.postCompactionReset = function postCompactionReset(offset) {
-  if (!this.live) throw new Error('postCompactionReset only works with live')
-  if (this.max || this.max_inclusive) {
-    throw new Error('postCompactionReset only works with no upper bound')
-  }
   this.cursor = Math.min(offset, this.cursor)
   this.min = null
   this.min_inclusive = null

--- a/stream.js
+++ b/stream.js
@@ -183,6 +183,16 @@ Stream.prototype.liveResume = function liveResume() {
   this.resume()
 }
 
+Stream.prototype.postCompactionReset = function postCompactionReset(offset) {
+  if (!this.live) throw new Error('postCompactionReset only works with live')
+  if (this.max || this.max_inclusive) {
+    throw new Error('postCompactionReset only works with no upper bound')
+  }
+  this.cursor = Math.min(offset, this.cursor)
+  this.min = null
+  this.min_inclusive = null
+}
+
 Stream.prototype.abort = function abort(err) {
   this.state = STREAM_STATE.ENDED
   this.log.streams.delete(this)


### PR DESCRIPTION
## Context

https://github.com/ssbc/ssb-replication-scheduler/issues/3

## Problem

Compaction waits for non-live streams to complete before applying the algorithm, but **live** streams remain as is, and they have a `cursor` which often points to the latest record at a very high offset. After compaction is done, the highest offset is smaller because the log got smaller, but the live stream cursor is greater than that. This may cause EPARTIALREAD errors with RAF.

## Solution

When compaction is done, it "resets" all live streams by setting their cursor to `since.value`. This assumes a lot of things and may be dangerous in the future. To name these assumptions:

- We assume that all live streams have caught up with log
- We assume that no live stream uses `opts.lt` or `opts.lte`
- We assume that no live streams were set with `opts.gt` *higher* than the currently known logSize

This is why we can "rewind" the stream.cursor to match the latest record's offset (i.e. `since.value`) which for practical purposes is enough for us. A better solution in the future may involve passing `opts.getLT` as functions instead of `opts.lt` so that we can fetch the correct `lt` instead of guessing.

1st :x: 2nd :heavy_check_mark: 