### PR TITLE
Compaction disable browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ log.compact((err) => {
 })
 ```
 
+Note, this functionality is currently not available when running in a
+browser.
+
 ### Track progress of compactions
 
 As an [obz] observable:

--- a/index.js
+++ b/index.js
@@ -69,11 +69,18 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
   let deletedBytes = 0
   const since = Obv() // offset of last written record
   let compaction = null
-  const compactionProgress = Obv().set(
-    Compaction.stateFileExists(filename)
-      ? { percent: 0, done: false }
-      : { percent: 1, done: true, sizeDiff: 0 }
-  )
+  const compactionProgress = Obv()
+  if (typeof window !== 'undefined') {
+    // fs sync not working in browser
+    compactionProgress.set({ percent: 1, done: true, sizeDiff: 0 })
+  } else {
+    compactionProgress.set(
+      Compaction.stateFileExists(filename)
+        ? { percent: 0, done: false }
+        : { percent: 1, done: true, sizeDiff: 0 }
+    )
+  }
+
   const waitingCompaction = []
 
   onLoad(function maybeResumeCompaction() {


### PR DESCRIPTION
Right now this module no longer works in the browser. The main reason is the `fsSync` call in `stateFileExists` on start. Tried to make these changes as minimal as possible. Can confirm that with this and a minor fix in ssb-db2 that ssb-browser-core is working again with latest db2.