### PR TITLE
deleted record should not be considered invalid

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,7 +212,7 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
       if (length === EOB.asNumber) break
       const [dataBuf, recSize] = Record.read(blockBuf, offsetInRecord)
       const isLengthCorrupt = offsetInRecord + recSize > blockSize
-      const isDataCorrupt = !validateRecord(dataBuf)
+      const isDataCorrupt = !isBufferZero(dataBuf) && !validateRecord(dataBuf)
       if (isLengthCorrupt || isDataCorrupt) {
         fixBlock(blockBuf, offsetInRecord, blockStart, lastGoodOffset, cb)
         return


### PR DESCRIPTION
## Context

Working on ssb-memdb, which uses AAOL but with a JSON codec instead of a BIPF.

## Problem

Suppose you have a JSON codec, and `validateRecord` set up such that it does a JSON.parse. If you delete a record, and then close the log and re-load it, it will go through `validateRecord` but an empty buffer will throw an error on `JSON.parse` so the deleted record will be considered "invalid".

This causes all the subsequent part of the log to be wiped, when in reality only the deleted record should be considered `null` and the subsequent records should be loaded

## Solution

Only run `validateRecord` on non-empty buffers.

1st :x: 2nd :heavy_check_mark: 

## Was this affecting (Manyverse) prod?

Gladly, not! In ssb-db2 we use `bipf.decode(buf, 0)` in validateRecord, and for some **lucky** reason, `bipf.decode(emptyBuffer, 0)` is just the empty string `''`, so it does not throw any errors. Yay! That was ... super close to disaster :sweat_smile: .